### PR TITLE
fix: import-recipe-bookmarklet.md trailing slashes

### DIFF
--- a/docs/docs/documentation/community-guide/import-recipe-bookmarklet.md
+++ b/docs/docs/documentation/community-guide/import-recipe-bookmarklet.md
@@ -7,7 +7,9 @@ You can use bookmarklets to generate a bookmark that will take your current loca
 You can use a [bookmarklet generator site](https://caiorss.github.io/bookmarklet-maker/) and the code below to generate a bookmark for your site. Just change the `http://localhost:8080` to your sites web address and follow the instructions.
 
 ```js
-var url = document.URL;
+var url = document.URL.endsWith('/') ?
+    document.URL.slice(0, -1) :
+    document.URL;
 var mealie = "http://localhost:8080";
 var group_slug = "home" // Change this to your group slug. You can obtain this from your URL after logging-in to Mealie
 var use_keywords= "&use_keywords=1" // Optional - use keywords from recipe - update to "" if you don't want that


### PR DESCRIPTION
## What type of PR is this?

documentation

## What this PR does / why we need it:

Fixes the case where the recipe URL has a trailing slash. Previously, that would make the keywords and edit settings be ignored, because the resulting URL was malformed.

## Testing

Example url with trailing slash: https://www.allrecipes.com/recipe/8849/baked-chicken-nuggets/
